### PR TITLE
UMD Wrapping for Javascript and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,40 @@ Downloads:
   * [rison.py](http://freebase-python.googlecode.com/svn/trunk/freebase/rison.py) contains a decoder in Python. 
   * [Tim Fletcher](http://tfletcher.com/dev/) has implemented [Rison in Ruby](http://rison.rubyforge.org/) including both encoder and decoder. 
 
+
+### Quick Start (Javascript)
+
+Install with npm or copy in `js/rison.js` manually, the script is
+compatible with AMD and CommonJS (such as browserify or node), you
+can also drop it into a `<script>` tag, creating the `rison` global.
+
+Once installed you have the following methods available:
+```js
+var rison = require('rison');
+
+rison.encode({any: "json", yes: true});
+rison.encode_array(["A", "B", {supportsObjects: true}]);
+rison.encode_object({supportsObjects: true, ints: 435});
+
+// Rison
+rison.encode({any: "json", yes: true});
+// (any:json,yes:!t)
+
+// O-Rison
+rison.encode_object({supportsObjects: true, ints: 435});
+// ints:435,supportsObjects:!t
+
+// A-Rison
+rison.encode_array(["A", "B", {supportsObjects: true}]);
+// A,B,(supportsObjects:!t)
+
+// Decode with: rison.decode, rison.decode_object, rison.decode_array
+// Example:
+rison.encode('(any:json,yes:!t)');
+// { any: 'json', yes: true }
+```
+
+
 ### Why another data serialization format?
 
 Rison is intended to meet the following goals, in roughly this order:

--- a/js/rison.js
+++ b/js/rison.js
@@ -1,5 +1,18 @@
-
-
+// Uses CommonJS, AMD or browser globals to create a module.
+// Based on: https://github.com/umdjs/umd/blob/master/commonjsStrict.js
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['exports'], factory);
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        factory(exports);
+    } else {
+        // Browser globals
+        factory((root.rison = {}));
+    }
+}(this, function (exports) {
+var rison = exports;
 
 //////////////////////////////////////////////////
 //
@@ -502,3 +515,5 @@ rison.parser.prototype.next = function () {
     return c;
 };
 
+// End of UMD module wrapper
+}));

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 
 {
   "name":         "rison",
-  "version":      "0.1.0",
+  "version":      "0.1.1",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "URI friendly encoding for JSON structures",
   "license":      "Apache-2.0",
   "repository": {
     "type":   "git",
     "url":    "https://github.com/jonasfj/rison.git"
-  }
+  },
+  "main":         "js/rison.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+
+{
+  "name":         "rison",
+  "version":      "0.1.0",
+  "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
+  "description":  "URI friendly encoding for JSON structures",
+  "license":      "Apache-2.0",
+  "repository": {
+    "type":   "git",
+    "url":    "https://github.com/jonasfj/rison.git"
+  }
+}


### PR DESCRIPTION
Employed a simple UMD wrapper for `rison.js` making it loadable using AMD, CommonJS (browserify, node), or includable using a `<script src="js/rison.js"></script>` tag.

I also took the liberty of creating a `package.json` file and publishing the module to NPM.
If you're interested I would love to add you as owner of the npm package, just drop me your NPM username :)

Btw, the example page is down, perhaps we should make a static one and host it on github pages, so it won't go away...
