### PR TITLE
Silently ignore undefined values

### DIFF
--- a/js/rison.js
+++ b/js/rison.js
@@ -197,7 +197,8 @@ rison.quote = function(x) {
                 return "'" + x + "'";
             },
             undefined: function (x) {
-                throw new Error("rison can't encode the undefined value");
+                // ignore undefined just like JSON
+                return;
             }
         };
 


### PR DESCRIPTION
This PR makes `rison.encode()` act more like `JSON.stringify()`

When attempting to encode an _undefined_ value, it simple ignores it and removes it from the final rison output.

I'm not sure if this goes against the spec or not, but I thought I'd offer it up anyway. If you don't like the change, just feel free to just close this PR.
