### PR TITLE
Add a bower.json to allow installation via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "rison",
+  "description": "URI friendly encoding for JSON structures",
+  "main": "js/rison.js",
+  "authors": [
+    "Jonas Finnemann Jensen <jopsen@gmail.com>"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [
+    "rison"
+  ],
+  "homepage": "https://github.com/Nanonid/rison",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
With reference to #13 , with this merged, a simple `bower register rison https://github.com/Nanonid/rison` ought to do the trick.
