### PR TITLE
Fixed package.json typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 {
   "name":         "rison",
   "version":      "0.1.2",
-  "author":       "Metaweb Technologies <devolopers@freebase.com>"
+  "author":       "Metaweb Technologies <devolopers@freebase.com>",
   "description":  "URI friendly encoding for JSON structures",
   "license":      "MIT",
   "repository": {


### PR DESCRIPTION
There's a missing comma in the package.json file which prevents using NPM.

`$ npm install https://github.com/Nanonid/rison.git`

fails without this patch. I've tested the patch on my fork and it works again.