### PR TITLE
Prevent quoting numeric keys

### DIFF
--- a/js/rison.js
+++ b/js/rison.js
@@ -173,7 +173,7 @@ rison.quote = function(x) {
                     if (typeof x.__prototype__ === 'object' && typeof x.__prototype__.encode_rison !== 'undefined')
                         return x.encode_rison();
 
-                    var a = ['('], b, f, i, v, ki, ks=[];
+                    var a = ['('], b, i, v, k, ki, ks=[];
                     for (i in x)
                         ks[ks.length] = i;
                     ks.sort();
@@ -184,7 +184,8 @@ rison.quote = function(x) {
                             if (b) {
                                 a[a.length] = ',';
                             }
-                            a.push(s.string(i), ':', v);
+                            k = isNaN(parseInt(i)) ? s.string(i) : s.number(i)
+                            a.push(k, ':', v);
                             b = true;
                         }
                     }


### PR DESCRIPTION
Although object keys are always strings, it's cheaper to treat them as numbers where applicable, esp when url encoding...


*current*
`'1':(locationID:-2)`

*url encoded*
`%271%27:(locationID:-2)`

*proposed*
`1:(locationID:-2)`