### PR TITLE
Bumped the version to v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rison",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "test": "mocha js/rison.spec.js"
   },


### PR DESCRIPTION
With the package.json file broken for v0.1.2, it would be good to bump the package version. 

Semantically, I can't see any new features or breaking changes so should be v0.1.3. I've tagged the commit "v0.1.3", so that it can be referenced easily when installing via npm or yarn, but I'm not sure if the tag will come across with the PR.