### PR TITLE
Fix: Validate decode input

### DIFF
--- a/js/rison.js
+++ b/js/rison.js
@@ -280,6 +280,11 @@ rison.quote = function(x) {
  */
 rison.decode = function(r) {
     var errcb = function(e) { throw Error('rison decoder error: ' + e); };
+
+    // validate input is a string
+    if (typeof r !== 'string')
+        return errcb('decode input must be a string');
+
     var p = new rison.parser(errcb);
     return p.parse(r);
 };

--- a/js/rison.spec.js
+++ b/js/rison.spec.js
@@ -47,6 +47,11 @@ describe('Rison', function() {
 
         expect(deserializedDeeplyNested).to.deep.equal(deeplyNested);
     })
+
+    it('Should throw when not given a string', function() {
+        const nonSting = {};
+        expect (() => rison.decode(nonSting)).to.throw('decode input must be a string');
+    });
 })
 
 describe('O-Rison', function() {


### PR DESCRIPTION
When decode is given a non-string value, an error is thrown saying "s.charAt is not a function". It makes sense, but isn't particularly helpful.

This PR check the value's type before trying to parse it, throwing the message "decode input must be a string" is the value isn't a string.

- Checks type in `decode`
- Adds test for non-string input